### PR TITLE
Added missing ntpd handler

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: ntpd
+  command: sv restart ntpd


### PR DESCRIPTION
Current role fails due to lack of ntpd handler. Adding the handler causes to role to complete successfully. 
